### PR TITLE
Fix local installation

### DIFF
--- a/bin/registerBabel.js
+++ b/bin/registerBabel.js
@@ -1,5 +1,5 @@
 require('babel-polyfill');
-const { dirname, join } = require('path');
+const { dirname } = require('path');
 const fs = require('fs');
 const babelRc = JSON.parse(fs.readFileSync(`${__dirname}/../.babelrc`, 'utf8'));
 
@@ -14,16 +14,8 @@ function ignore(filename) {
 }
 
 function buildPath(type, name) {
-  /* 
-   When it's running locally, the executable is inside "$ROOT/node_modules/.bin/cry|battlecry".
-   Globally it's only "/bin/cry|battlecry"
-  */
-  const isLocal = process.argv.some(arg => arg.includes('.bin'));
-
-  const localPath = join(__dirname, `../../babel-${type}-${name}`);
-  const globalPath = join(__dirname, `/../node_modules/babel-${type}-${name}`);
-
-  return isLocal ? localPath : globalPath;
+  const pkg = `babel-${type}-${name}`;
+  return dirname(require.resolve(`${pkg}/package.json`));
 }
 
 function buildPresets() {

--- a/bin/registerBabel.js
+++ b/bin/registerBabel.js
@@ -1,5 +1,5 @@
 require('babel-polyfill');
-const dirname = require('path').dirname;
+const { dirname, join } = require('path');
 const fs = require('fs');
 const babelRc = JSON.parse(fs.readFileSync(`${__dirname}/../.babelrc`, 'utf8'));
 
@@ -14,7 +14,16 @@ function ignore(filename) {
 }
 
 function buildPath(type, name) {
-  return `${__dirname}/../node_modules/babel-${type}-${name}`;
+  /* 
+   When it's running locally, the executable is inside "$ROOT/node_modules/.bin/cry|battlecry".
+   Globally it's only "/bin/cry|battlecry"
+  */
+  const isLocal = process.argv.some(arg => arg.includes('.bin'));
+
+  const localPath = join(__dirname, `../../babel-${type}-${name}`);
+  const globalPath = join(__dirname, `/../node_modules/babel-${type}-${name}`);
+
+  return isLocal ? localPath : globalPath;
 }
 
 function buildPresets() {


### PR DESCRIPTION
# Explanation

## Global dependencies
So, first I'd like to explain why `battlecry` works globally.

When `bin/registerBabel.js` is required, it gets all babel dependencies paths using `buildPath` method, which will concatenate the `__dirname` with `../node_modules/babel-${type}-${name}`.

As result of this method, it'll generate something like this:

```
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-preset-flow
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-preset-env
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-preset-stage-0
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-plugin-transform-async-to-generator
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-plugin-transform-decorators-legacy
/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-plugin-module-resolver
```

But that's fine, because using global dependencies, we have the following (or similar) folder structure:
```
.node/
├── bin/
|   ├── ...others
|   ├── battlecry -> ../lib/node_modules/battlecry/bin/battlecry.js
|   └── cry -> ../lib/node_modules/battlecry/bin/battlecry.js
├── include/
└── lib/
    ├── ...others
    ├── npm
    └── node_modules
          ├── ...others
          └── battlecry
                ├── ...others
                ├── bin/
                |    └── registerBabel.js
                └── node_modules/
                      └── ...all battlecry dependencies
```

In a nutshell, global dependencies has inside it folder a `node_modules` folder containing all `production dependencies`.

## Local Dependencies

When we install a local dependency in a project, we have a folder structure quite different from global:

```
.
├── README.md
├── node_modules/
|   ├── .bin/ 
|   |     ├── dep1 -> ../dep1/bin/dep1.js (FILE specificied in `main` at package.json)
|   |     ├── dep2 -> ../dep2/lib/index.js (FILE specificied in `main` at package.json)
|   |     └── dep3 -> ../dep3/dep3/bin.js (FILE specificied in `main` at package.json)
|   ├── dep1/
|   ├── dep2/
|   ├── dep5/
|   ├── ...
|   ├── dep88/
|   ├── ...
|   └── depN
├── src/
├── package.json
└── yarn.lock
```

## The issue

When we try to install `battlecry` locally, we have the following error:

```
ReferenceError: Unknown plugin "/Users/raulmelo/Desktop/test-cry/node_modules/battlecry/bin/../node_modules/babel-plugin-transform-async-to-generator" specified in "base"
```

That's because the lib assumes we have node modules inside the dependency (battlecry) folder:

```
. my-awesome-project
└── node_modules/
     └── battlecry
          ├── node_modules/ <--- THIS FOLDER DOESN'T EXISTS BECAUSE IT's A LOCAL DEPENDENCY
          └── bin
               └── battlecry.js
```

And considering how local dependencies are structured, this error makes total sense.

## Solution

Basically to solve this error, we have to know which context where running (`global` or `local`). For our luck, the binary folder in both context are different:

-  **bin** for global (`node/bin/battlecry`)
- **.bin** for local (e.g. `project/node_modules/.bin/battlecry`)

My solution was validate the args from node (`process.arg`) because when we run both `yarn battlecry` and `cry`, we have:

- process.arg[0] => path to node
- process.arg[1] => path to `battlecry` file 
- process.arg[n] => other arguments

and once we have this difference (bin and .bin) I just check which context we are running and return a appropriate path.

**Join**

I implement using `join` from `path module` because it resolve our `'../'` path:

From: `/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/../node_modules/babel-preset-flow`

To: `/Users/raulmelo/.nvm/versions/node/v10.10.0/lib/node_modules/battlecry/node_modules/babel-preset-flow`

## Final words

Hope I could be clear about the problem and the solution. Soon I'll open another PR restructuring the folders and refactoring some small pieces of code! :)

Cheers 🍻 
